### PR TITLE
fix: update all dependencies from open Dependabot PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tiptap/extension-color": "^2.6.6",
     "@tiptap/extension-image": "^2.6.6",
     "@tiptap/extension-text-style": "^2.6.6",
-    "@tiptap/html": "2.1.13",
+    "@tiptap/html": "2.2.4",
     "@tiptap/pm": "^2.6.6",
     "@tiptap/starter-kit": "^2.6.6",
     "@tiptap/vue-3": "^2.6.6",
@@ -39,15 +39,18 @@
     "focus-trap": "^7.5.4",
     "lucide-vue-next": "^0.438.0",
     "nuxt-umami": "^2.6.4",
+    "path-to-regexp": "6.3.0",
     "pinia": "^2.2.2",
     "radix-vue": "^1.9.5",
+    "serve-static": "1.16.2",
     "supabase": "^1.191.3",
     "tailwind-merge": "^2.5.2",
     "tailwindcss": "3.4.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul-vue": "^0.2.0",
     "vue-draggable-plus": "^0.5.3",
-    "vue-sonner": "^1.1.5"
+    "vue-sonner": "^1.1.5",
+    "ws": "8.17.1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.0.0",
@@ -68,7 +71,7 @@
     "shadcn-nuxt": "^0.10.4",
     "typescript": "^5.5.4",
     "unhead": "^1.10.0",
-    "vite": "^5.4.2",
+    "vite": "^5.1.6",
     "vue": "^3.4.38"
   }
 }


### PR DESCRIPTION
This PR updates all dependencies that had open Dependabot PRs:

- Update @tiptap/html from 2.1.13 to 2.2.4
- Add path-to-regexp 6.3.0 (fixes backtracking protection)
- Add serve-static 1.16.2
- Add ws 8.17.1 (fixes DoS vulnerability)
- Update vite from 5.4.2 to 5.1.6

This resolves the following issues:
- #212
- #218
- #227
- #234
- #236